### PR TITLE
Set values of newly created Charge during Invoice.pay

### DIFF
--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -61,7 +61,8 @@ module StripeMock
           id: charge_id,
           customer: invoices[$1][:customer],
           created: Time.now.utc.to_i,
-          invoice: invoices[$1][:id]
+          invoice: invoices[$1][:id],
+          amount: subscriptions[invoices[$1][:subscription]][:plan][:amount]
         }
         charges[charge_id] = Data.mock_charge(charge_params)
 

--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -60,7 +60,8 @@ module StripeMock
         charge_params = {
           id: charge_id,
           customer: invoices[$1][:customer],
-          created: Time.now.utc.to_i
+          created: Time.now.utc.to_i,
+          invoice: invoices[$1][:id]
         }
         charges[charge_id] = Data.mock_charge(charge_params)
 


### PR DESCRIPTION
A new Stripe Charge is made during invoice.pay for monthly payment. The new charge tho doesn't set its invoice field value which is defaulted to nil.
